### PR TITLE
Replace Claude Code devcontainer feature with npm install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts"
-    },
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+    }
   },
   "remoteEnv": {
     "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:PATH}"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 # Install global npm tools
-npm install -g markdownlint-cli2
+npm install -g @anthropic-ai/claude-code markdownlint-cli2
+
+# Ensure Claude Code config directory exists with correct ownership
+mkdir -p "$HOME/.claude/debug"
 
 # Verify all tools are available
 echo "--- Tool verification ---"
@@ -11,6 +14,7 @@ yamllint --version
 golangci-lint version
 gh --version
 node --version
+claude --version
 markdownlint-cli2 --version
 
 # Check Go module cache volume permissions


### PR DESCRIPTION
## Summary
- Removed `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` from devcontainer features due to EACCES permission errors and ECONNREFUSED failures during container setup
- Added `@anthropic-ai/claude-code` to npm global install in `post-create.sh`, which runs as the `vscode` user and avoids timing/permission issues
- Pre-created `$HOME/.claude/debug` directory to prevent runtime permission errors

## Test plan
- [ ] Rebuild the devcontainer from scratch and verify it completes without errors
- [ ] Run `claude --version` inside the container to confirm Claude Code is installed
- [ ] Verify OAuth login flow works without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration and setup process to optimize tool installation and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->