### PR TITLE
Mount host Claude config into devcontainer via bind mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
   ],
   "mounts": [
     "source=sigrok-mcp-server-go-mod-cache,target=/go/pkg/mod,type=volume",
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind"
   ],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Create Claude config directory
-        run: mkdir -p ~/.claude
+        run: mkdir -p ~/.claude && touch ~/.claude.json
 
       - name: Build devcontainer
         uses: devcontainers/ci@v0.3


### PR DESCRIPTION
## Summary
- Bind mount host `~/.claude` and `~/.claude.json` into devcontainer using `${localEnv:HOME}` for Claude Code authentication sharing
- Keep `build.dockerfile` + `mounts` approach (no Docker Compose needed)
- CI workflow creates dummy `~/.claude` directory and `~/.claude.json` file to prevent bind mount failures

## Key decisions
- `claude login` must be run on the Docker host (OAuth callback port forwarding doesn't work inside containers)
- `${localEnv:HOME}` resolves to the remote host's `$HOME` when using Remote-SSH, which is the desired behavior
- Both `~/.claude` directory and `~/.claude.json` file are required for Claude Code authentication

## Test plan
- [x] CI passes with dummy Claude config files
- [x] Devcontainer builds and starts correctly via Remote-SSH + Reopen in Container
- [x] Claude Code authentication works inside the container (shared from host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)