### PR TITLE
Add check_firmware_status tool and firmware diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that 
 | `scan_devices` | Scan for connected hardware devices |
 | `capture_data` | Capture communication data from a device and save to file |
 | `decode_protocol` | Decode protocol data from a captured file using protocol decoders |
+| `check_firmware_status` | Check firmware file availability in sigrok firmware directories |
 
 ## Quickstart
 
@@ -64,7 +65,7 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-To pass a USB device through to the container:
+To access USB devices from the container:
 
 ```json
 {
@@ -77,11 +78,42 @@ To pass a USB device through to the container:
 }
 ```
 
+To also provide firmware files for devices that require them (e.g. Kingst LA2016):
+
+```json
+{
+  "mcpServers": {
+    "sigrok": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--privileged",
+        "-v", "/path/to/sigrok-firmware:/usr/local/share/sigrok-firmware:ro",
+        "sigrok-mcp-server"
+      ]
+    }
+  }
+}
+```
+
 ### Claude Code
 
 ```bash
 claude mcp add sigrok -- docker run -i --rm sigrok-mcp-server
 ```
+
+With USB access and firmware:
+
+```bash
+claude mcp add sigrok -- docker run -i --rm --privileged -v /path/to/sigrok-firmware:/usr/local/share/sigrok-firmware:ro sigrok-mcp-server
+```
+
+## Firmware
+
+Some hardware drivers require firmware files that cannot be bundled with this server due to licensing restrictions. The server works without firmware for devices that don't need it (e.g. `demo`, protocol-only analysis). For devices that require firmware (e.g. Kingst LA2016, Saleae Logic16), mount your firmware directory into the container at `/usr/local/share/sigrok-firmware`.
+
+Use the `check_firmware_status` tool to verify firmware availability and diagnose device detection issues.
+
+See the [sigrok wiki](https://sigrok.org/wiki/Firmware) for firmware extraction instructions for your device.
 
 ## Architecture
 

--- a/cmd/sigrok-mcp-server/main.go
+++ b/cmd/sigrok-mcp-server/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	cfg := config.Load()
 	executor := sigrok.NewExecutor(cfg.SigrokCLIPath, cfg.Timeout, cfg.WorkingDir)
-	handlers := tools.NewHandlers(executor)
+	handlers := tools.NewHandlers(executor, config.FirmwareDirs())
 
 	srv := server.NewMCPServer("sigrok-mcp-server", "0.1.0")
 	tools.RegisterAll(srv, handlers)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 )
@@ -40,4 +41,18 @@ func Load() Config {
 	}
 
 	return cfg
+}
+
+// FirmwareDirs returns the standard sigrok firmware search directories.
+// These match the paths that libsigrok searches at runtime.
+func FirmwareDirs() []string {
+	dirs := []string{}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".local", "share", "sigrok-firmware"))
+	}
+	dirs = append(dirs,
+		"/usr/local/share/sigrok-firmware",
+		"/usr/share/sigrok-firmware",
+	)
+	return dirs
 }

--- a/internal/sigrok/parser.go
+++ b/internal/sigrok/parser.go
@@ -57,6 +57,27 @@ type DecodeResult struct {
 	Format string `json:"format"`
 }
 
+// ScanResult holds the result of a scan_devices operation.
+type ScanResult struct {
+	Devices  []ScannedDevice `json:"devices"`
+	Warnings []string        `json:"warnings,omitempty"`
+	Hint     string          `json:"hint,omitempty"`
+}
+
+// FirmwareStatus holds the result of a firmware directory check.
+type FirmwareStatus struct {
+	Directories []FirmwareDirectory `json:"directories"`
+	TotalFiles  int                 `json:"total_files"`
+	Hint        string              `json:"hint,omitempty"`
+}
+
+// FirmwareDirectory describes a single firmware search directory.
+type FirmwareDirectory struct {
+	Path   string   `json:"path"`
+	Exists bool     `json:"exists"`
+	Files  []string `json:"files,omitempty"`
+}
+
 // ParseListSection extracts items from a named section of sigrok-cli -L output.
 // sectionHeader should match the full header line, e.g. "Supported hardware drivers:".
 func ParseListSection(output, sectionHeader string) []ListItem {

--- a/internal/tools/handlers.go
+++ b/internal/tools/handlers.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/KenosInc/sigrok-mcp-server/internal/sigrok"
@@ -27,12 +29,13 @@ type Runner interface {
 
 // Handlers holds MCP tool handler functions.
 type Handlers struct {
-	runner Runner
+	runner       Runner
+	firmwareDirs []string
 }
 
-// NewHandlers creates a new Handlers with the given executor.
-func NewHandlers(runner Runner) *Handlers {
-	return &Handlers{runner: runner}
+// NewHandlers creates a new Handlers with the given executor and firmware directories.
+func NewHandlers(runner Runner, firmwareDirs []string) *Handlers {
+	return &Handlers{runner: runner, firmwareDirs: firmwareDirs}
 }
 
 // HandleListSupportedHardware returns all supported hardware drivers.
@@ -133,11 +136,23 @@ func (h *Handlers) HandleScanDevices(ctx context.Context, _ mcp.CallToolRequest)
 		return toolError(fmt.Sprintf("sigrok-cli execution failed: %v", err)), nil
 	}
 	if result.ExitCode != 0 {
-		return toolError(result.Stderr), nil
+		msg := nonEmptyError(result)
+		if isFirmwareError(msg) {
+			msg += "\n\nHint: Some devices require firmware files that are not bundled with the server. " +
+				"Use the check_firmware_status tool to diagnose, or mount firmware into the container with: " +
+				"docker run -v /path/to/firmware:/usr/local/share/sigrok-firmware:ro"
+		}
+		return toolError(msg), nil
 	}
 
-	devices := sigrok.ParseScanDevices(result.Stdout)
-	return jsonResult(devices)
+	scanResult := sigrok.ScanResult{
+		Devices: sigrok.ParseScanDevices(result.Stdout),
+	}
+	if warnings := extractFirmwareWarnings(result.Stderr); len(warnings) > 0 {
+		scanResult.Warnings = warnings
+		scanResult.Hint = "Some devices may not have been detected due to missing firmware. Use the check_firmware_status tool to diagnose."
+	}
+	return jsonResult(scanResult)
 }
 
 // HandleCaptureData captures communication data from a device and saves to file.
@@ -301,6 +316,65 @@ func (h *Handlers) HandleDecodeProtocol(ctx context.Context, req mcp.CallToolReq
 		Output: result.Stdout,
 		Format: format,
 	})
+}
+
+// HandleCheckFirmwareStatus checks firmware file availability in standard sigrok directories.
+func (h *Handlers) HandleCheckFirmwareStatus(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	status := sigrok.FirmwareStatus{
+		Directories: make([]sigrok.FirmwareDirectory, 0, len(h.firmwareDirs)),
+	}
+
+	for _, dir := range h.firmwareDirs {
+		fd := sigrok.FirmwareDirectory{Path: dir}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			fd.Exists = false
+			status.Directories = append(status.Directories, fd)
+			continue
+		}
+		fd.Exists = true
+		for _, e := range entries {
+			if !e.IsDir() {
+				fd.Files = append(fd.Files, e.Name())
+			}
+		}
+		status.TotalFiles += len(fd.Files)
+		status.Directories = append(status.Directories, fd)
+	}
+
+	if status.TotalFiles == 0 {
+		status.Hint = "No firmware files found. Some hardware drivers (e.g. kingst-la2016, saleae-logic16) " +
+			"require firmware files that cannot be redistributed. Mount your firmware directory into the container: " +
+			"docker run -v /path/to/firmware:/usr/local/share/sigrok-firmware:ro ..."
+	}
+
+	return jsonResult(status)
+}
+
+// isFirmwareError checks if an error message indicates a firmware-related failure.
+func isFirmwareError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "firmware") ||
+		strings.Contains(lower, "failed to open resource") ||
+		strings.Contains(lower, ".fw") ||
+		strings.Contains(lower, ".bitstream")
+}
+
+// extractFirmwareWarnings extracts firmware-related warning lines from stderr.
+func extractFirmwareWarnings(stderr string) []string {
+	if stderr == "" {
+		return nil
+	}
+	var warnings []string
+	for _, line := range strings.Split(stderr, "\n") {
+		if isFirmwareError(line) {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				warnings = append(warnings, trimmed)
+			}
+		}
+	}
+	return warnings
 }
 
 func nonEmptyError(result *sigrok.CommandResult) string {

--- a/internal/tools/handlers_test.go
+++ b/internal/tools/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -54,7 +55,7 @@ func assertTextResult(t *testing.T, result *mcp.CallToolResult, errExpected bool
 
 func TestRegisterAll(t *testing.T) {
 	srv := server.NewMCPServer("test", "0.0.1")
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 	RegisterAll(srv, h)
 
 	ctx := context.Background()
@@ -104,6 +105,7 @@ func TestRegisterAll(t *testing.T) {
 		"show_version":            true,
 		"capture_data":            true,
 		"decode_protocol":         true,
+		"check_firmware_status":   true,
 	}
 
 	if len(parsed.Result.Tools) != len(wantTools) {
@@ -155,7 +157,7 @@ func TestHandleShowVersion(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleShowVersion(context.Background(), makeRequest("show_version", nil))
 	if err != nil {
@@ -183,7 +185,7 @@ func TestHandleListSupportedHardware(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleListSupportedHardware(context.Background(), makeRequest("list_supported_hardware", nil))
 	if err != nil {
@@ -214,7 +216,7 @@ func TestHandleListSupportedDecoders(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleListSupportedDecoders(context.Background(), makeRequest("list_supported_decoders", nil))
 	if err != nil {
@@ -242,7 +244,7 @@ func TestHandleListInputFormats(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleListInputFormats(context.Background(), makeRequest("list_input_formats", nil))
 	if err != nil {
@@ -270,7 +272,7 @@ func TestHandleListOutputFormats(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleListOutputFormats(context.Background(), makeRequest("list_output_formats", nil))
 	if err != nil {
@@ -298,7 +300,7 @@ func TestHandleShowDecoderDetails(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleShowDecoderDetails(context.Background(), makeRequest("show_decoder_details", map[string]any{"decoder": "uart"}))
 	if err != nil {
@@ -320,7 +322,7 @@ func TestHandleShowDecoderDetails(t *testing.T) {
 }
 
 func TestHandleShowDecoderDetailsMissingParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleShowDecoderDetails(context.Background(), makeRequest("show_decoder_details", nil))
 	if err != nil {
@@ -331,7 +333,7 @@ func TestHandleShowDecoderDetailsMissingParam(t *testing.T) {
 }
 
 func TestHandleShowDecoderDetailsInvalidParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	tests := []struct {
 		name    string
@@ -359,7 +361,7 @@ func TestHandleShowDriverDetails(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleShowDriverDetails(context.Background(), makeRequest("show_driver_details", map[string]any{"driver": "demo"}))
 	if err != nil {
@@ -381,7 +383,7 @@ func TestHandleShowDriverDetails(t *testing.T) {
 }
 
 func TestHandleShowDriverDetailsMissingParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleShowDriverDetails(context.Background(), makeRequest("show_driver_details", nil))
 	if err != nil {
@@ -392,7 +394,7 @@ func TestHandleShowDriverDetailsMissingParam(t *testing.T) {
 }
 
 func TestHandleShowDriverDetailsInvalidParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleShowDriverDetails(context.Background(), makeRequest("show_driver_details", map[string]any{"driver": "--evil-flag"}))
 	if err != nil {
@@ -409,7 +411,7 @@ func TestHandleScanDevices(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleScanDevices(context.Background(), makeRequest("scan_devices", nil))
 	if err != nil {
@@ -421,22 +423,134 @@ func TestHandleScanDevices(t *testing.T) {
 	}
 
 	text := assertTextResult(t, result, false)
-	var devices []sigrok.ScannedDevice
-	if err := json.Unmarshal([]byte(text), &devices); err != nil {
+	var scanResult sigrok.ScanResult
+	if err := json.Unmarshal([]byte(text), &scanResult); err != nil {
 		t.Fatalf("failed to parse JSON: %v", err)
 	}
-	if len(devices) != 1 {
-		t.Fatalf("expected 1 device, got %d", len(devices))
+	if len(scanResult.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(scanResult.Devices))
 	}
-	if devices[0].Driver != "demo" {
-		t.Errorf("driver = %q, want %q", devices[0].Driver, "demo")
+	if scanResult.Devices[0].Driver != "demo" {
+		t.Errorf("driver = %q, want %q", scanResult.Devices[0].Driver, "demo")
+	}
+	if len(scanResult.Warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", scanResult.Warnings)
+	}
+}
+
+func TestHandleScanDevicesWithFirmwareWarnings(t *testing.T) {
+	mock := &mockExecutor{
+		result: &sigrok.CommandResult{
+			Stdout:   "The following devices were found:\ndemo - Demo device with 13 channels\n",
+			Stderr:   "sr: kingst-la2016: Failed to open resource 'kingst-la-01a2.fw'\nsr: kingst-la2016: MCU firmware upload failed\n",
+			ExitCode: 0,
+		},
+	}
+	h := NewHandlers(mock, nil)
+
+	result, err := h.HandleScanDevices(context.Background(), makeRequest("scan_devices", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := assertTextResult(t, result, false)
+	var scanResult sigrok.ScanResult
+	if err := json.Unmarshal([]byte(text), &scanResult); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	if len(scanResult.Warnings) != 2 {
+		t.Fatalf("expected 2 warnings, got %d: %v", len(scanResult.Warnings), scanResult.Warnings)
+	}
+	if scanResult.Hint == "" {
+		t.Error("expected non-empty hint")
+	}
+}
+
+func TestHandleScanDevicesFirmwareError(t *testing.T) {
+	mock := &mockExecutor{
+		result: &sigrok.CommandResult{
+			Stderr:   "Failed to open resource 'kingst-la-01a2.fw'",
+			ExitCode: 1,
+		},
+	}
+	h := NewHandlers(mock, nil)
+
+	result, err := h.HandleScanDevices(context.Background(), makeRequest("scan_devices", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := assertTextResult(t, result, true)
+	if !strings.Contains(text, "Hint:") {
+		t.Errorf("expected firmware hint in error, got %q", text)
+	}
+	if !strings.Contains(text, "check_firmware_status") {
+		t.Errorf("expected check_firmware_status reference in error, got %q", text)
+	}
+}
+
+func TestHandleCheckFirmwareStatusWithFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"kingst-la-01a2.fw", "kingst-la2016-fpga.bitstream"} {
+		if err := os.WriteFile(tmpDir+"/"+name, []byte("test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h := NewHandlers(&mockExecutor{}, []string{tmpDir, "/nonexistent/path"})
+
+	result, err := h.HandleCheckFirmwareStatus(context.Background(), makeRequest("check_firmware_status", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := assertTextResult(t, result, false)
+	var status sigrok.FirmwareStatus
+	if err := json.Unmarshal([]byte(text), &status); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	if status.TotalFiles != 2 {
+		t.Errorf("total_files = %d, want 2", status.TotalFiles)
+	}
+	if len(status.Directories) != 2 {
+		t.Fatalf("expected 2 directories, got %d", len(status.Directories))
+	}
+	if !status.Directories[0].Exists {
+		t.Error("expected first directory to exist")
+	}
+	if status.Directories[1].Exists {
+		t.Error("expected second directory to not exist")
+	}
+	if status.Hint != "" {
+		t.Errorf("expected empty hint when files are present, got %q", status.Hint)
+	}
+}
+
+func TestHandleCheckFirmwareStatusEmpty(t *testing.T) {
+	h := NewHandlers(&mockExecutor{}, []string{"/nonexistent/path1", "/nonexistent/path2"})
+
+	result, err := h.HandleCheckFirmwareStatus(context.Background(), makeRequest("check_firmware_status", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := assertTextResult(t, result, false)
+	var status sigrok.FirmwareStatus
+	if err := json.Unmarshal([]byte(text), &status); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	if status.TotalFiles != 0 {
+		t.Errorf("total_files = %d, want 0", status.TotalFiles)
+	}
+	if status.Hint == "" {
+		t.Error("expected non-empty hint when no firmware found")
 	}
 }
 
 func TestHandlerExecutionError(t *testing.T) {
 	h := NewHandlers(&mockExecutor{
 		err: errors.New("binary not found"),
-	})
+	}, nil)
 
 	// Execution errors should be returned as tool errors (IsError=true),
 	// not as Go errors, so LLMs can see the failure message.
@@ -458,7 +572,7 @@ func TestHandleCaptureData(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "fx2lafw",
@@ -499,7 +613,7 @@ func TestHandleCaptureDataWithAllOptions(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":       "demo",
@@ -540,7 +654,7 @@ func TestHandleCaptureDataWithAllOptions(t *testing.T) {
 }
 
 func TestHandleCaptureDataMissingDriver(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"samples": float64(1000),
@@ -552,7 +666,7 @@ func TestHandleCaptureDataMissingDriver(t *testing.T) {
 }
 
 func TestHandleCaptureDataMissingSamplesAndTime(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver": "demo",
@@ -564,7 +678,7 @@ func TestHandleCaptureDataMissingSamplesAndTime(t *testing.T) {
 }
 
 func TestHandleCaptureDataInvalidParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	tests := []struct {
 		name string
@@ -595,7 +709,7 @@ func TestHandleDecodeProtocol(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleDecodeProtocol(context.Background(), makeRequest("decode_protocol", map[string]any{
 		"input_file":        "capture.sr",
@@ -630,7 +744,7 @@ func TestHandleDecodeProtocolWithAllOptions(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleDecodeProtocol(context.Background(), makeRequest("decode_protocol", map[string]any{
 		"input_file":          "capture.sr",
@@ -669,7 +783,7 @@ func TestHandleDecodeProtocolWithAllOptions(t *testing.T) {
 }
 
 func TestHandleDecodeProtocolMissingParams(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	tests := []struct {
 		name string
@@ -691,7 +805,7 @@ func TestHandleDecodeProtocolMissingParams(t *testing.T) {
 }
 
 func TestHandleDecodeProtocolInvalidParam(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	tests := []struct {
 		name string
@@ -721,7 +835,7 @@ func TestHandleCaptureDataTimeOnly(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	h := NewHandlers(mock)
+	h := NewHandlers(mock, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver": "demo",
@@ -751,7 +865,7 @@ func TestHandleCaptureDataTimeOnly(t *testing.T) {
 }
 
 func TestHandleCaptureDataNegativeSamples(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "demo",
@@ -768,7 +882,7 @@ func TestHandleCaptureDataNegativeSamples(t *testing.T) {
 }
 
 func TestHandleCaptureDataNegativeTime(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "demo",
@@ -785,7 +899,7 @@ func TestHandleCaptureDataNegativeTime(t *testing.T) {
 }
 
 func TestHandleCaptureDataOverflowSamples(t *testing.T) {
-	h := NewHandlers(&mockExecutor{})
+	h := NewHandlers(&mockExecutor{}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "demo",
@@ -800,7 +914,7 @@ func TestHandleCaptureDataOverflowSamples(t *testing.T) {
 func TestHandleCaptureDataExecutionError(t *testing.T) {
 	h := NewHandlers(&mockExecutor{
 		err: errors.New("binary not found"),
-	})
+	}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "demo",
@@ -822,7 +936,7 @@ func TestHandleCaptureDataNonZeroExit(t *testing.T) {
 			Stderr:   "Error: device not found",
 			ExitCode: 1,
 		},
-	})
+	}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "fx2lafw",
@@ -845,7 +959,7 @@ func TestHandleCaptureDataNonZeroExitEmptyStderr(t *testing.T) {
 			Stderr:   "",
 			ExitCode: 1,
 		},
-	})
+	}, nil)
 
 	result, err := h.HandleCaptureData(context.Background(), makeRequest("capture_data", map[string]any{
 		"driver":  "demo",
@@ -867,7 +981,7 @@ func TestHandleCaptureDataNonZeroExitEmptyStderr(t *testing.T) {
 func TestHandleDecodeProtocolExecutionError(t *testing.T) {
 	h := NewHandlers(&mockExecutor{
 		err: errors.New("binary not found"),
-	})
+	}, nil)
 
 	result, err := h.HandleDecodeProtocol(context.Background(), makeRequest("decode_protocol", map[string]any{
 		"input_file":        "capture.sr",
@@ -889,7 +1003,7 @@ func TestHandleDecodeProtocolNonZeroExit(t *testing.T) {
 			Stderr:   "Error: input file not found",
 			ExitCode: 1,
 		},
-	})
+	}, nil)
 
 	result, err := h.HandleDecodeProtocol(context.Background(), makeRequest("decode_protocol", map[string]any{
 		"input_file":        "missing.sr",
@@ -912,7 +1026,7 @@ func TestHandleDecodeProtocolNonZeroExitEmptyStderr(t *testing.T) {
 			Stderr:   "",
 			ExitCode: 2,
 		},
-	})
+	}, nil)
 
 	result, err := h.HandleDecodeProtocol(context.Background(), makeRequest("decode_protocol", map[string]any{
 		"input_file":        "capture.sr",
@@ -935,7 +1049,7 @@ func TestHandlerNonZeroExit(t *testing.T) {
 			Stderr:   "Error: unknown protocol decoder 'foo'.\n",
 			ExitCode: 1,
 		},
-	})
+	}, nil)
 
 	result, err := h.HandleShowDecoderDetails(context.Background(), makeRequest("show_decoder_details", map[string]any{"decoder": "foo"}))
 	if err != nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -44,8 +44,12 @@ func RegisterAll(srv *server.MCPServer, h *Handlers) {
 	), h.HandleShowVersion)
 
 	srv.AddTool(mcp.NewTool("scan_devices",
-		mcp.WithDescription("Scan for connected hardware devices. Returns an array of {driver, description} objects."),
+		mcp.WithDescription("Scan for connected hardware devices. Returns {devices, warnings, hint} where devices is an array of {driver, description} objects. Warnings indicate firmware-related issues for devices that could not be initialized."),
 	), h.HandleScanDevices)
+
+	srv.AddTool(mcp.NewTool("check_firmware_status",
+		mcp.WithDescription("Check firmware file availability in standard sigrok firmware directories. Returns which directories exist and what firmware files are present. Use this to diagnose device detection issues caused by missing firmware."),
+	), h.HandleCheckFirmwareStatus)
 
 	srv.AddTool(mcp.NewTool("capture_data",
 		mcp.WithDescription("Capture communication data from a connected device and save to file. Either 'samples' or 'time' must be specified."),


### PR DESCRIPTION
## Summary
- Add `check_firmware_status` MCP tool that inspects standard libsigrok firmware directories and reports which files are present, enabling LLMs to self-diagnose device detection failures
- Enhance `scan_devices` to surface firmware-related warnings from stderr and append actionable hints (mount instructions, tool reference) when firmware errors are detected
- Update README with firmware volume mount examples for Claude Desktop and Claude Code, and add a Firmware section explaining licensing constraints

## Test plan
- [x] `go test ./... -race` — all tests pass
- [x] `go vet ./...` — no issues
- [x] Manual: run `check_firmware_status` with firmware mounted → verify files listed
- [x] Manual: run `check_firmware_status` without firmware → verify hint returned
- [x] Manual: run `scan_devices` with missing firmware → verify warning/hint in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a firmware status checking tool for verifying firmware file availability across configured directories.
  * Enhanced device scanning to surface firmware-related warnings and guidance hints.

* **Documentation**
  * Updated configuration guides with firmware provisioning examples and mounting instructions.
  * Added sigrok firmware directory references and extraction resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->