### PR TITLE
Add OWON XDM1241 SCPI command reference

### DIFF
--- a/docs/devices/owon-xdm1241.md
+++ b/docs/devices/owon-xdm1241.md
@@ -1,0 +1,114 @@
+# OWON XDM1241 SCPI Reference
+
+## Overview
+
+The OWON XDM1241 is a 4 1/2 digit bench-type digital multimeter with USB serial connectivity. It is a variant of the XDM1041 (battery-powered, USB-C powered instead of AC mains). Internally it uses a CH340 USB-to-serial chip.
+
+sigrok's `scpi-dmm` driver does not recognize this device. Use the `serial_query` MCP tool for direct SCPI communication.
+
+## Connection Parameters
+
+| Parameter | Value |
+|---|---|
+| Port | `/dev/ttyUSB0` (typical) |
+| Baud rate | 115200 |
+| Data bits | 8 |
+| Parity | None |
+| Stop bits | 1 |
+| Timeout | 3000 ms (recommended) |
+
+## Command Conventions
+
+The XDM1241 uses a **non-standard, flat SCPI command set**. Key differences from standard SCPI:
+
+- **No subsystem hierarchy**: Commands like `MEAS:VOLT:DC?`, `VOLT:RANG?`, or `SYST:ERR?` are not supported and will time out with no response.
+- **Display suffix**: Many commands use a numeric suffix (`1` = main display, `2` = sub display). Commands without a suffix default to the main display.
+- **Write responses**: Non-query commands (those not ending in `?`) return `OK\n` or `nOK\n` (firmware v25052021+).
+- **Line terminator**: Responses are terminated with `\n`. Commands should be sent with `\n`.
+
+## Verified Commands
+
+Tested on firmware V4.3.0 via `serial_query` MCP tool.
+
+### Device Identification
+
+| Command | Example Response | Description |
+|---|---|---|
+| `*IDN?` | `OWON,XDM1241,24412417,V4.3.0,3` | Device identification (manufacturer, model, serial, firmware, unknown) |
+
+### Measurement
+
+| Command | Example Response | Description |
+|---|---|---|
+| `MEAS?` | `-2.758856E-05` | Read main display value (shorthand for `MEAS1?`) |
+| `MEAS1?` | `-2.758856E-05` | Read main display value |
+| `MEAS2?` | `NONe` | Read sub display value (`NONe` if sub display is off) |
+
+### Function / Mode
+
+| Command | Example Response | Description |
+|---|---|---|
+| `FUNC?` | `"VOLT"` | Current function on main display |
+| `FUNC1?` | `"VOLT"` | Current function on main display (explicit) |
+| `FUNC2?` | `NONe` | Current function on sub display |
+
+### Range
+
+| Command | Example Response | Description |
+|---|---|---|
+| `RANGE1?` | `50 mV` | Current range on main display |
+| `AUTO1?` | `1` | Auto-range status on main display (1=on, 0=off) |
+
+### Sampling Rate
+
+| Command | Example Response | Description |
+|---|---|---|
+| `RATE?` | `S` | Sampling rate (`S`=Slow, `M`=Medium, `F`=Fast) |
+
+## Commands That Do NOT Work
+
+These standard SCPI commands time out with no response:
+
+- `MEAS:VOLT:DC?` (standard SCPI measurement)
+- `VOLT:RANG?`, `VOLT:RANG:AUTO?`
+- `SYST:ERR?`
+- `CONF?`
+- `RANG?`
+- `*RST` (no response; may or may not execute)
+- `VAL1?`, `VAL2?`
+- `RANGE2?` (when sub display is off)
+
+## Usage Examples
+
+### Read voltage with serial_query
+
+```
+Tool: serial_query
+Parameters:
+  port: /dev/ttyUSB0
+  command: MEAS1?
+  baudrate: 115200
+  timeout_ms: 3000
+```
+
+Response: `{"response": "-2.758856E-05"}`
+
+### Identify the device
+
+```
+Tool: serial_query
+Parameters:
+  port: /dev/ttyUSB0
+  command: *IDN?
+  baudrate: 115200
+  timeout_ms: 2000
+```
+
+Response: `{"response": "OWON,XDM1241,24412417,V4.3.0,3"}`
+
+## References
+
+- [TheHWcave/OWON-XDM1041](https://github.com/TheHWcave/OWON-XDM1041) - Community SCPI command list and firmware info
+- [Elektroarzt/owon-xdm-remote](https://github.com/Elektroarzt/owon-xdm-remote) - ESP32 remote control using SCPI over WiFi/MQTT
+- [OWON XDM1000 Programming Manual](https://files.owon.com.cn/software/Application/XDM1000_Digital_Multimeter_Programming_Manual.pdf) - Official (incomplete) documentation
+- [Owon XDM2041 - sigrok wiki](https://sigrok.org/wiki/Owon_XDM2041) - Related model in sigrok


### PR DESCRIPTION
## Summary
- Documents the OWON XDM1241's non-standard SCPI command set in `docs/devices/owon-xdm1241.md`
- Covers verified commands (MEAS1?, FUNC1?, RANGE1?, RATE?, AUTO1?, *IDN?), connection parameters, and commands that do NOT work (standard SCPI subsystem syntax)
- Explains why sigrok's scpi-dmm driver fails to recognize this device: it uses flat commands instead of hierarchical SCPI

## Test plan
- [x] All commands verified on real hardware (OWON XDM1241, firmware V4.3.0) via `serial_query` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the OWON XDM1241 device, including device overview, USB connectivity information, SCPI command reference with verified commands and examples, connection parameters, and compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->