### PR TITLE
Add dedicated yamllint CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,6 @@ jobs:
         with:
           version: v2.8.0
 
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Run yamllint
-        uses: frenck/action-yamllint@v1
-
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,31 @@
+name: YAML Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run yamllint
+        run: yamllint --strict .

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,7 @@
 extends: default
 
 rules:
+  document-start: disable
   line-length:
     max: 120
   truthy:


### PR DESCRIPTION
## Summary

- Extract yamllint from `ci.yml` into a dedicated `.github/workflows/yamllint.yml` workflow with `paths` filter for `**.yml` / `**.yaml` files
- Replace `frenck/action-yamllint` third-party action with direct `yamllint --strict .` execution (pre-installed on `ubuntu-latest`)
- Disable `document-start` rule in `.yamllint.yml` since the project convention omits `---` markers and `--strict` treats warnings as errors

## Test plan

- [x] `yamllint --strict .` passes locally with zero warnings
- [x] New YAML Lint workflow triggers on PRs that modify YAML files
- [x] CI workflow still passes without the removed yamllint job

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized YAML linting workflow to run as a separate CI job with enhanced configuration, improving code quality validation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->