### PR TITLE
docs: add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that wraps [sigrok-cli](https://sigrok.org/wiki/Sigrok-cli), exposing sigrok's signal analysis capabilities to LLMs. It translates MCP tool calls into `sigrok-cli` invocations and returns structured JSON results, enabling LLMs to query logic analyzers, decode protocols, and analyze signals.
 
+**[Documentation](https://kenosinc.github.io/sigrok-mcp-server)** | **[Getting Started](https://kenosinc.github.io/sigrok-mcp-server/getting-started/installation/)**
+
 ## Tools
 
 | Tool | Description |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,57 @@
+# Architecture
+
+## Overview
+
+```
+MCP Client (LLM)
+    |  stdio (JSON-RPC)
+    v
+sigrok-mcp-server (Go)
+    |  exec.Command
+    v
+sigrok-cli
+    |
+    v
+libsigrok / libsigrokdecode
+```
+
+- **Transport:** stdio (stdin/stdout JSON-RPC)
+- **No C bindings:** sigrok-cli is the sole interface to sigrok
+- **Structured output:** Raw sigrok-cli text output is parsed into JSON
+
+## Package structure
+
+```
+cmd/sigrok-mcp-server/     Entry point
+internal/
+  config/                  Environment-based configuration
+  sigrok/
+    executor.go            sigrok-cli command execution with timeout
+    parser.go              Output parsing (list, decoder, driver, version, scan)
+    testdata/              Real sigrok-cli output fixtures
+  serial/                  Serial port querier (independent of sigrok-cli)
+  devices/                 Device profile registry with embedded JSON profiles
+  tools/
+    tools.go               MCP tool definitions and registration
+    handlers.go            Tool handler implementations
+```
+
+## Key design decisions
+
+### sigrok-cli as the sole interface
+
+The server does not use C bindings or link against libsigrok directly. Instead, it shells out to `sigrok-cli` for all sigrok operations. This simplifies the build (pure Go binary), avoids CGO complexity, and leverages the same CLI tool that sigrok users already know.
+
+### Command injection prevention
+
+All user-provided inputs are validated with regexes before being passed to `sigrok-cli`. Filenames are restricted to flat names (no path separators) to prevent path traversal.
+
+### Testability
+
+- `Runner` interface in `internal/tools/` enables mock-based handler tests
+- `CommandFactory` in `internal/sigrok/executor.go` is a test seam for injecting fake commands
+- Golden output files in `internal/sigrok/testdata/` enable parser tests without sigrok-cli
+
+### serial_query independence
+
+The `serial_query` and `get_device_profile` tools operate independently of sigrok-cli, using a pure Go serial library. This allows instrument communication even when sigrok's SCPI driver doesn't support the device.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Contributions to sigrok-mcp-server are welcome!
+
+## Development setup
+
+### Using the dev container (recommended)
+
+The repository includes a dev container configuration. Open the project in VS Code or any IDE with dev container support, or use:
+
+```bash
+devcontainer up
+```
+
+### Local setup
+
+Requirements:
+
+- Go 1.23+
+- sigrok-cli (for integration testing)
+
+```bash
+# Build
+go build ./...
+
+# Test
+go test ./... -race
+
+# Lint
+go vet ./...
+golangci-lint run ./...
+```
+
+## Code style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Use table-driven tests with `t.Run()` subtests
+- Error handling: return errors, don't panic; wrap with `fmt.Errorf("context: %w", err)`
+- Naming: exported names in PascalCase, unexported in camelCase
+
+## Pull requests
+
+1. Fork the repository and create a feature branch
+2. Make your changes with tests
+3. Ensure `go test ./... -race` passes
+4. Ensure `go vet ./...` reports no issues
+5. Submit a pull request against `main`
+
+## Areas for contribution
+
+- **Device documentation:** Test with your hardware and document the results in `docs/devices/`
+- **Protocol decode examples:** Share real-world decode workflows in `docs/guides/`
+- **Bug fixes and improvements:** Check [open issues](https://github.com/KenosInc/sigrok-mcp-server/issues)
+- **Device profiles:** Add JSON profiles for new instruments in `internal/devices/`
+
+## Reporting issues
+
+Please use [GitHub Issues](https://github.com/KenosInc/sigrok-mcp-server/issues) to report bugs or request features.

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -1,0 +1,20 @@
+# Devices
+
+This section documents devices that have been tested with sigrok-mcp-server, including connection settings, verified commands, and device-specific notes.
+
+## Tested Devices
+
+| Device | Type | Connection | Notes |
+|---|---|---|---|
+| [OWON XDM1241](owon-xdm1241.md) | Digital multimeter | USB serial (CH340) | Non-standard SCPI, use `serial_query` |
+
+## Adding device documentation
+
+If you've tested a device with sigrok-mcp-server, contributions are welcome! See [Contributing](../development/contributing.md) for how to submit device documentation.
+
+A device page should include:
+
+- Overview and connection parameters
+- Verified commands and expected responses
+- Commands that do **not** work (to save others from troubleshooting)
+- Usage examples with the appropriate MCP tools

--- a/docs/getting-started/firmware.md
+++ b/docs/getting-started/firmware.md
@@ -1,0 +1,44 @@
+# Firmware
+
+Some hardware drivers require firmware files that cannot be bundled with this server due to licensing restrictions.
+
+## Which devices need firmware?
+
+Devices that require firmware upload on connection include:
+
+- **Kingst LA2016** / LA1016 / LA5016
+- **Saleae Logic16**
+- **fx2lafw**-based analyzers (many low-cost USB logic analyzers)
+
+Devices that do **not** need firmware:
+
+- The `demo` virtual driver (always works)
+- Protocol-only analysis (decoding from files)
+- Some standalone instruments (SCPI multimeters, oscilloscopes)
+
+## Checking firmware status
+
+Use the `check_firmware_status` tool to verify firmware availability:
+
+```
+Tool: check_firmware_status
+```
+
+This reports which firmware directories exist and what files are present, helping diagnose device detection issues.
+
+## Providing firmware (Docker)
+
+Mount your firmware directory into the container:
+
+```bash
+docker run -i --rm --privileged \
+  -v /path/to/sigrok-firmware:/usr/local/share/sigrok-firmware:ro \
+  sigrok-mcp-server
+```
+
+## Where to get firmware
+
+See the [sigrok wiki on firmware](https://sigrok.org/wiki/Firmware) for extraction instructions for your specific device. Each device has different firmware sources and extraction methods.
+
+!!! note
+    Firmware files are typically extracted from vendor software installers. The sigrok wiki provides step-by-step instructions for each supported device.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,57 @@
+# Installation
+
+## Docker (recommended)
+
+Docker is the easiest way to get started — sigrok-cli and all dependencies are bundled in the image.
+
+```bash
+docker build -t sigrok-mcp-server .
+```
+
+Then run:
+
+```bash
+docker run -i --rm sigrok-mcp-server
+```
+
+!!! tip
+    Once pre-built images are available on Docker Hub, you'll be able to skip the build step entirely with `docker pull`.
+
+## From source
+
+Requires:
+
+- **Go 1.23+**
+- **sigrok-cli** installed on your system ([sigrok installation guide](https://sigrok.org/wiki/Downloads))
+
+```bash
+go build -o sigrok-mcp-server ./cmd/sigrok-mcp-server
+./sigrok-mcp-server
+```
+
+## Configuration
+
+Configuration is done via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `SIGROK_CLI_PATH` | `sigrok-cli` | Path to the sigrok-cli binary |
+| `SIGROK_TIMEOUT_SECONDS` | `30` | Command execution timeout in seconds |
+| `SIGROK_WORKING_DIR` | current dir | Working directory for sigrok-cli execution |
+
+For Docker, pass environment variables with `-e`:
+
+```bash
+docker run -i --rm -e SIGROK_TIMEOUT_SECONDS=60 sigrok-mcp-server
+```
+
+## USB device access (Docker)
+
+To access USB-connected devices (logic analyzers, oscilloscopes, etc.) from inside the container:
+
+```bash
+docker run -i --rm --privileged sigrok-mcp-server
+```
+
+!!! warning
+    `--privileged` grants broad access to host devices. For production use, consider using `--device` to pass specific USB devices instead.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,76 @@
+# Quick Start
+
+After [installing](installation.md) the server, configure your MCP client to connect to it.
+
+## Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+=== "Basic"
+
+    ```json
+    {
+      "mcpServers": {
+        "sigrok": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm", "sigrok-mcp-server"]
+        }
+      }
+    }
+    ```
+
+=== "With USB access"
+
+    ```json
+    {
+      "mcpServers": {
+        "sigrok": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm", "--privileged", "sigrok-mcp-server"]
+        }
+      }
+    }
+    ```
+
+=== "With USB + firmware"
+
+    ```json
+    {
+      "mcpServers": {
+        "sigrok": {
+          "command": "docker",
+          "args": [
+            "run", "-i", "--rm", "--privileged",
+            "-v", "/path/to/sigrok-firmware:/usr/local/share/sigrok-firmware:ro",
+            "sigrok-mcp-server"
+          ]
+        }
+      }
+    }
+    ```
+
+## Claude Code
+
+=== "Basic"
+
+    ```bash
+    claude mcp add sigrok -- docker run -i --rm sigrok-mcp-server
+    ```
+
+=== "With USB + firmware"
+
+    ```bash
+    claude mcp add sigrok -- docker run -i --rm --privileged \
+      -v /path/to/sigrok-firmware:/usr/local/share/sigrok-firmware:ro \
+      sigrok-mcp-server
+    ```
+
+## Verify the connection
+
+Once configured, ask the LLM to run the `show_version` tool. You should see sigrok-cli and library version information returned, confirming the server is running correctly.
+
+## What's next?
+
+- Browse [available tools](../tools/index.md) to see what you can do
+- Check the [workflow example](../guides/workflow-example.md) for a typical signal analysis session
+- If your device needs firmware, see the [firmware guide](../getting-started/firmware.md)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,79 @@
+# Troubleshooting
+
+## Device not found
+
+**Symptom:** `scan_devices` returns no devices.
+
+**Possible causes:**
+
+1. **USB not passed through (Docker):** Use `--privileged` or `--device` flag.
+
+    ```bash
+    docker run -i --rm --privileged sigrok-mcp-server
+    ```
+
+2. **Missing firmware:** Run `check_firmware_status` to verify. See the [firmware guide](../getting-started/firmware.md).
+
+3. **Permission denied:** On Linux, ensure your user is in the `plugdev` group, or use udev rules for the device.
+
+## Timeout errors
+
+**Symptom:** Commands fail with a timeout error.
+
+**Possible causes:**
+
+1. **Slow device:** Increase the timeout via environment variable:
+
+    ```bash
+    docker run -i --rm -e SIGROK_TIMEOUT_SECONDS=120 sigrok-mcp-server
+    ```
+
+2. **Serial timeout too short:** For `serial_query`, increase `timeout_ms` (some instruments are slow to respond):
+
+    ```
+    Tool: serial_query
+    Parameters:
+      port: /dev/ttyUSB0
+      command: "*IDN?"
+      timeout_ms: 5000
+    ```
+
+## Decoder produces no output
+
+**Symptom:** `decode_protocol` returns empty results.
+
+**Possible causes:**
+
+1. **Wrong channel mapping:** Ensure decoder channels match the capture channels. Use `show_decoder_details` to see required channels.
+
+2. **Wrong baud rate / protocol settings:** Verify settings match the actual signal.
+
+3. **No transitions in data:** The capture may not contain the expected signal activity.
+
+## sigrok-cli not found
+
+**Symptom:** Server fails to start or tools return "sigrok-cli not found" errors.
+
+**Possible causes:**
+
+1. **Not using Docker:** The Docker image bundles sigrok-cli. If running from source, install it separately.
+
+2. **Custom path:** Set `SIGROK_CLI_PATH` if sigrok-cli is installed in a non-standard location.
+
+## Serial port access denied
+
+**Symptom:** `serial_query` returns a permission error.
+
+**Possible causes:**
+
+1. **Docker:** The serial device must be passed through:
+
+    ```bash
+    docker run -i --rm --device=/dev/ttyUSB0 sigrok-mcp-server
+    ```
+
+2. **Linux permissions:** Add your user to the `dialout` group:
+
+    ```bash
+    sudo usermod -a -G dialout $USER
+    ```

--- a/docs/guides/workflow-example.md
+++ b/docs/guides/workflow-example.md
@@ -1,0 +1,84 @@
+# Workflow Example
+
+This guide walks through a typical signal analysis session using the MCP tools.
+
+## Scenario
+
+You have a logic analyzer connected via USB and want to capture and decode UART communication.
+
+## Step 1: Scan for devices
+
+First, discover what hardware is connected:
+
+```
+Tool: scan_devices
+```
+
+The LLM sees the connected logic analyzer and its driver ID.
+
+## Step 2: Check driver capabilities
+
+Inspect the driver to understand configuration options:
+
+```
+Tool: show_driver_details
+Parameters:
+  driver: fx2lafw
+```
+
+This reveals supported sample rates, channel counts, and other capabilities.
+
+## Step 3: Capture data
+
+Capture signal data from the device:
+
+```
+Tool: capture_data
+Parameters:
+  driver: fx2lafw
+  channels: D0
+  config: samplerate=1M
+  samples: 1000000
+```
+
+The captured data is saved to a file.
+
+## Step 4: Decode the protocol
+
+Apply a UART decoder to the captured data:
+
+```
+Tool: decode_protocol
+Parameters:
+  input_file: capture_20260224_120000.sr
+  protocol_decoders: uart:baudrate=9600:rx=D0
+```
+
+## Step 5: LLM analysis
+
+The LLM receives the decoded output — individual bytes, frames, and timing information — and can:
+
+- Explain what the communication means
+- Identify protocol errors or anomalies
+- Suggest next steps (different baud rate, additional channels, stacked decoders)
+
+## Working with serial instruments
+
+For SCPI-capable instruments (multimeters, power supplies, etc.), you can communicate directly:
+
+```
+Tool: get_device_profile
+Parameters:
+  query: XDM1241
+```
+
+Then query the instrument using the profile's settings:
+
+```
+Tool: serial_query
+Parameters:
+  port: /dev/ttyUSB0
+  command: "MEAS?"
+  baudrate: 115200
+  timeout_ms: 3000
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# sigrok-mcp-server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that wraps [sigrok-cli](https://sigrok.org/wiki/Sigrok-cli), exposing sigrok's signal analysis capabilities to LLMs.
+
+It translates MCP tool calls into `sigrok-cli` invocations and returns structured JSON results, enabling LLMs to query logic analyzers, decode protocols, and analyze signals.
+
+## What can it do?
+
+- **Discover hardware** — Scan for connected logic analyzers, oscilloscopes, and multimeters
+- **Capture data** — Acquire signal data from devices and save to files
+- **Decode protocols** — Analyze captured data with 100+ protocol decoders (UART, SPI, I2C, etc.)
+- **Query instruments** — Send SCPI commands directly to serial-attached instruments
+- **Browse capabilities** — List supported drivers, decoders, and file formats
+
+## Available Tools
+
+| Tool | Description |
+|---|---|
+| [`list_supported_hardware`](tools/list-supported-hardware.md) | List all supported hardware drivers |
+| [`list_supported_decoders`](tools/list-supported-decoders.md) | List all supported protocol decoders |
+| [`list_input_formats`](tools/list-input-formats.md) | List all supported input file formats |
+| [`list_output_formats`](tools/list-output-formats.md) | List all supported output file formats |
+| [`show_decoder_details`](tools/show-decoder-details.md) | Show detailed info about a protocol decoder |
+| [`show_driver_details`](tools/show-driver-details.md) | Show detailed info about a hardware driver |
+| [`show_version`](tools/show-version.md) | Show sigrok-cli and library version info |
+| [`scan_devices`](tools/scan-devices.md) | Scan for connected hardware devices |
+| [`capture_data`](tools/capture-data.md) | Capture data from a device and save to file |
+| [`decode_protocol`](tools/decode-protocol.md) | Decode protocol data from a captured file |
+| [`check_firmware_status`](tools/check-firmware-status.md) | Check firmware file availability |
+| [`serial_query`](tools/serial-query.md) | Send commands over a serial port |
+| [`get_device_profile`](tools/get-device-profile.md) | Look up device profiles and connection settings |
+
+## Quick Example
+
+A typical signal analysis workflow with an LLM:
+
+1. **Discover** — `scan_devices` to find connected hardware
+2. **Inspect** — `show_driver_details` to check driver capabilities
+3. **Capture** — `capture_data` to acquire signal data
+4. **Decode** — `decode_protocol` to analyze with protocol decoders
+5. **Understand** — The LLM interprets decoded output and explains the communication
+
+## Getting Started
+
+See the [Installation](getting-started/installation.md) guide to get up and running.

--- a/docs/tools/capture-data.md
+++ b/docs/tools/capture-data.md
@@ -1,0 +1,54 @@
+# capture_data
+
+Capture communication data from a connected device and save to file.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `driver` | string | Yes | Hardware driver ID (e.g. `fx2lafw`, `demo`) |
+| `conn` | string | No | Connection string for serial/network devices |
+| `config` | string | No | Device configuration (e.g. `samplerate=1M`) |
+| `channels` | string | No | Channels to use (e.g. `D0,D1,D2`) |
+| `samples` | number | No* | Number of samples to acquire |
+| `time` | number | No* | How long to sample in milliseconds |
+| `triggers` | string | No | Trigger configuration (e.g. `D0=r`) |
+| `wait_trigger` | boolean | No | Wait for trigger before capturing |
+| `output_file` | string | No | Output filename (auto-generated if omitted) |
+
+*Either `samples` or `time` must be specified.
+
+## Returns
+
+Information about the captured file, including the path to the saved data.
+
+## Examples
+
+### Capture with the demo driver
+
+```
+Tool: capture_data
+Parameters:
+  driver: demo
+  config: samplerate=1M
+  samples: 1000000
+```
+
+### Capture from a real device with trigger
+
+```
+Tool: capture_data
+Parameters:
+  driver: fx2lafw
+  channels: D0,D1
+  config: samplerate=4M
+  samples: 2000000
+  triggers: D0=r
+  wait_trigger: true
+```
+
+## Notes
+
+- The output file can be passed to [`decode_protocol`](decode-protocol.md) for analysis.
+- If `output_file` is omitted, a filename is generated automatically.
+- Use [`scan_devices`](scan-devices.md) first to discover available devices and their drivers.

--- a/docs/tools/check-firmware-status.md
+++ b/docs/tools/check-firmware-status.md
@@ -1,0 +1,26 @@
+# check_firmware_status
+
+Check firmware file availability in standard sigrok firmware directories.
+
+## Parameters
+
+None.
+
+## Returns
+
+Information about:
+
+- Which firmware directories exist
+- What firmware files are present in each directory
+- Overall firmware status
+
+## Example
+
+```
+Tool: check_firmware_status
+```
+
+## Notes
+
+- Use this tool to diagnose device detection issues — missing firmware is the most common cause.
+- See the [firmware guide](../getting-started/firmware.md) for how to provide firmware files.

--- a/docs/tools/decode-protocol.md
+++ b/docs/tools/decode-protocol.md
@@ -1,0 +1,56 @@
+# decode_protocol
+
+Decode protocol data from a captured file using sigrok protocol decoders.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `input_file` | string | Yes | Input filename |
+| `protocol_decoders` | string | Yes | Protocol decoders to apply (e.g. `uart:baudrate=9600`) |
+| `input_format` | string | No | Input format (e.g. `vcd`, `binary`) |
+| `annotations` | string | No | Decoder annotation filter (e.g. `uart=rx-data`) |
+| `show_sample_numbers` | boolean | No | Include sample numbers in output |
+| `meta_output` | string | No | Decoder meta output filter (e.g. `uart=baud`) |
+| `json_trace` | boolean | No | Output in Google Trace Event JSON format |
+
+## Returns
+
+Decoded protocol data from the file.
+
+## Examples
+
+### Decode UART data
+
+```
+Tool: decode_protocol
+Parameters:
+  input_file: capture.sr
+  protocol_decoders: uart:baudrate=9600:rx=D0
+```
+
+### Decode SPI with annotation filter
+
+```
+Tool: decode_protocol
+Parameters:
+  input_file: capture.sr
+  protocol_decoders: spi:clk=D0:mosi=D1:miso=D2:cs=D3
+  annotations: spi=mosi-data
+```
+
+### Decode with JSON trace output
+
+```
+Tool: decode_protocol
+Parameters:
+  input_file: capture.sr
+  protocol_decoders: i2c:scl=D0:sda=D1
+  json_trace: true
+```
+
+## Notes
+
+- Use [`show_decoder_details`](show-decoder-details.md) to see available options and channels for a decoder.
+- Decoder options are specified inline with the decoder ID, separated by colons (e.g. `uart:baudrate=115200:rx=D0`).
+- Files are captured using [`capture_data`](capture-data.md) or imported from external sources.

--- a/docs/tools/get-device-profile.md
+++ b/docs/tools/get-device-profile.md
@@ -1,0 +1,40 @@
+# get_device_profile
+
+Look up a device profile by name, model, manufacturer, or `*IDN?` response string. Returns connection settings, supported commands with examples, and device-specific notes.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | Yes | Device name, model, manufacturer, or `*IDN?` response string to match against |
+
+## Returns
+
+Device profile including:
+
+- Connection settings (baudrate, parity, etc.)
+- Supported commands with examples
+- Device-specific notes and limitations
+
+## Examples
+
+### Look up by model name
+
+```
+Tool: get_device_profile
+Parameters:
+  query: XDM1241
+```
+
+### Look up by IDN response
+
+```
+Tool: get_device_profile
+Parameters:
+  query: "OWON,XDM1241,24412417,V4.3.0,3"
+```
+
+## Notes
+
+- Use this tool before [`serial_query`](serial-query.md) to get the correct settings for a device.
+- Profiles are embedded in the server; see [devices](../devices/index.md) for currently supported profiles.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,0 +1,44 @@
+# Tools Overview
+
+sigrok-mcp-server exposes the following MCP tools. Each tool translates into one or more `sigrok-cli` invocations and returns structured JSON results.
+
+## Discovery tools
+
+These tools query sigrok's capabilities and require no connected hardware.
+
+| Tool | Description |
+|---|---|
+| [`list_supported_hardware`](list-supported-hardware.md) | List all supported hardware drivers |
+| [`list_supported_decoders`](list-supported-decoders.md) | List all supported protocol decoders |
+| [`list_input_formats`](list-input-formats.md) | List all supported input file formats |
+| [`list_output_formats`](list-output-formats.md) | List all supported output file formats |
+| [`show_decoder_details`](show-decoder-details.md) | Show detailed info about a protocol decoder |
+| [`show_driver_details`](show-driver-details.md) | Show detailed info about a hardware driver |
+| [`show_version`](show-version.md) | Show sigrok-cli and library version info |
+
+## Device tools
+
+These tools interact with connected hardware.
+
+| Tool | Description |
+|---|---|
+| [`scan_devices`](scan-devices.md) | Scan for connected hardware devices |
+| [`capture_data`](capture-data.md) | Capture data from a device and save to file |
+| [`check_firmware_status`](check-firmware-status.md) | Check firmware file availability |
+
+## Analysis tools
+
+These tools process captured data.
+
+| Tool | Description |
+|---|---|
+| [`decode_protocol`](decode-protocol.md) | Decode protocol data from a captured file |
+
+## Instrument tools
+
+These tools communicate directly with serial-attached instruments, independent of sigrok-cli.
+
+| Tool | Description |
+|---|---|
+| [`serial_query`](serial-query.md) | Send commands over a serial port |
+| [`get_device_profile`](get-device-profile.md) | Look up device profiles and connection settings |

--- a/docs/tools/list-input-formats.md
+++ b/docs/tools/list-input-formats.md
@@ -1,0 +1,31 @@
+# list_input_formats
+
+List all supported input file formats.
+
+## Parameters
+
+None.
+
+## Returns
+
+An array of `{id, description}` objects, one per supported input format.
+
+## Example
+
+```
+Tool: list_input_formats
+```
+
+Response (excerpt):
+
+```json
+[
+  {"id": "binary", "description": "Raw binary logic data"},
+  {"id": "vcd", "description": "Value Change Dump data"},
+  {"id": "wav", "description": "WAV file"}
+]
+```
+
+## Notes
+
+- Input formats determine what file types can be used with [`decode_protocol`](decode-protocol.md).

--- a/docs/tools/list-output-formats.md
+++ b/docs/tools/list-output-formats.md
@@ -1,0 +1,31 @@
+# list_output_formats
+
+List all supported output file formats.
+
+## Parameters
+
+None.
+
+## Returns
+
+An array of `{id, description}` objects, one per supported output format.
+
+## Example
+
+```
+Tool: list_output_formats
+```
+
+Response (excerpt):
+
+```json
+[
+  {"id": "srzip", "description": "sigrok session file format data"},
+  {"id": "csv", "description": "Comma-separated values"},
+  {"id": "vcd", "description": "Value Change Dump data"}
+]
+```
+
+## Notes
+
+- Output formats determine the file format used by [`capture_data`](capture-data.md).

--- a/docs/tools/list-supported-decoders.md
+++ b/docs/tools/list-supported-decoders.md
@@ -1,0 +1,32 @@
+# list_supported_decoders
+
+List all supported protocol decoders.
+
+## Parameters
+
+None.
+
+## Returns
+
+An array of `{id, description}` objects, one per supported protocol decoder.
+
+## Example
+
+```
+Tool: list_supported_decoders
+```
+
+Response (excerpt):
+
+```json
+[
+  {"id": "uart", "description": "Universal Asynchronous Receiver/Transmitter"},
+  {"id": "spi", "description": "Serial Peripheral Interface"},
+  {"id": "i2c", "description": "Inter-Integrated Circuit"}
+]
+```
+
+## Notes
+
+- This is a read-only query that does not require connected hardware.
+- Use [`show_decoder_details`](show-decoder-details.md) to get full information about a specific decoder.

--- a/docs/tools/list-supported-hardware.md
+++ b/docs/tools/list-supported-hardware.md
@@ -1,0 +1,32 @@
+# list_supported_hardware
+
+List all supported hardware drivers.
+
+## Parameters
+
+None.
+
+## Returns
+
+An array of `{id, description}` objects, one per supported hardware driver.
+
+## Example
+
+```
+Tool: list_supported_hardware
+```
+
+Response (excerpt):
+
+```json
+[
+  {"id": "demo", "description": "Demo driver and target"},
+  {"id": "fx2lafw", "description": "fx2lafw (generic driver for FX2 based LAs)"},
+  {"id": "kingst-la2016", "description": "Kingst LA2016"}
+]
+```
+
+## Notes
+
+- This is a read-only query that does not require connected hardware.
+- The list comes from the sigrok-cli installation inside the container.

--- a/docs/tools/scan-devices.md
+++ b/docs/tools/scan-devices.md
@@ -1,0 +1,43 @@
+# scan_devices
+
+Scan for connected hardware devices.
+
+## Parameters
+
+All parameters are optional. When no parameters are provided, a broad scan is performed.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `driver` | string | No | Hardware driver ID for targeted scanning (e.g. `scpi-dmm`, `rigol-ds`) |
+| `conn` | string | No | Connection string for targeted scanning (e.g. `/dev/ttyUSB0:serialcomm=115200/8n1`) |
+
+## Returns
+
+An object with:
+
+- `devices` — Array of `{driver, description}` objects for detected devices
+- `warnings` — Firmware-related issues for devices that could not be initialized
+- `hint` — Suggestions for resolving issues
+
+## Examples
+
+### Broad scan
+
+```
+Tool: scan_devices
+```
+
+### Targeted scan for a serial instrument
+
+```
+Tool: scan_devices
+Parameters:
+  driver: scpi-dmm
+  conn: /dev/ttyUSB0:serialcomm=115200/8n1
+```
+
+## Notes
+
+- Broad scans may take several seconds depending on available drivers.
+- Warnings about firmware typically indicate that a device was detected but its firmware files are missing. See the [firmware guide](../getting-started/firmware.md).
+- SCPI driver categories: `scpi-dmm` (multimeters), `scpi-pps` (power supplies), or vendor-specific like `rigol-ds` (oscilloscopes).

--- a/docs/tools/serial-query.md
+++ b/docs/tools/serial-query.md
@@ -1,0 +1,48 @@
+# serial_query
+
+Send a command string over a serial port and return the device response. Works with any serial-attached instrument that accepts text commands (e.g. SCPI). Independent of sigrok-cli.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `port` | string | Yes | Serial device path (e.g. `/dev/ttyUSB0`) |
+| `command` | string | Yes | Command to send (e.g. `*IDN?`, `MEAS:VOLT:DC?`) |
+| `baudrate` | number | No | Baud rate (default: 9600) |
+| `databits` | number | No | Data bits: 5, 6, 7, or 8 (default: 8) |
+| `parity` | string | No | Parity: `none`, `odd`, `even`, `mark`, `space` (default: `none`) |
+| `stopbits` | string | No | Stop bits: `1`, `1.5`, `2` (default: `1`) |
+| `timeout_ms` | number | No | Read timeout in milliseconds (default: 1000) |
+
+## Returns
+
+The device response string.
+
+## Examples
+
+### Identify a device
+
+```
+Tool: serial_query
+Parameters:
+  port: /dev/ttyUSB0
+  command: "*IDN?"
+  baudrate: 115200
+  timeout_ms: 3000
+```
+
+### Read a voltage measurement
+
+```
+Tool: serial_query
+Parameters:
+  port: /dev/ttyUSB0
+  command: "MEAS:VOLT:DC?"
+  baudrate: 9600
+```
+
+## Notes
+
+- This tool communicates directly over serial and does **not** use sigrok-cli.
+- Use [`get_device_profile`](get-device-profile.md) to look up correct connection settings before querying an unknown device.
+- See [device documentation](../devices/index.md) for device-specific command references.

--- a/docs/tools/show-decoder-details.md
+++ b/docs/tools/show-decoder-details.md
@@ -1,0 +1,31 @@
+# show_decoder_details
+
+Show detailed information about a specific protocol decoder, including options, channels, annotation classes, and documentation.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `decoder` | string | Yes | Protocol decoder ID (e.g. `uart`, `spi`, `i2c`) |
+
+## Returns
+
+Detailed information about the decoder including:
+
+- Description and documentation
+- Required and optional channels
+- Configurable options with defaults
+- Annotation classes (output categories)
+
+## Example
+
+```
+Tool: show_decoder_details
+Parameters:
+  decoder: uart
+```
+
+## Notes
+
+- Use [`list_supported_decoders`](list-supported-decoders.md) to discover available decoder IDs.
+- Decoder options (e.g. `baudrate`, `parity`) are passed via the `protocol_decoders` parameter in [`decode_protocol`](decode-protocol.md).

--- a/docs/tools/show-driver-details.md
+++ b/docs/tools/show-driver-details.md
@@ -1,0 +1,30 @@
+# show_driver_details
+
+Show detailed information about a specific hardware driver, including supported functions, scan options, and connected devices.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `driver` | string | Yes | Hardware driver ID (e.g. `demo`, `fx2lafw`, `rigol-ds`) |
+
+## Returns
+
+Detailed information about the driver including:
+
+- Supported functions and capabilities
+- Scan options (connection parameters, serial settings)
+- Detected devices (if any are connected)
+
+## Example
+
+```
+Tool: show_driver_details
+Parameters:
+  driver: fx2lafw
+```
+
+## Notes
+
+- Use [`list_supported_hardware`](list-supported-hardware.md) to discover available driver IDs.
+- This tool may trigger a device scan for the specified driver.

--- a/docs/tools/show-version.md
+++ b/docs/tools/show-version.md
@@ -1,0 +1,26 @@
+# show_version
+
+Show sigrok-cli version information, including library versions.
+
+## Parameters
+
+None.
+
+## Returns
+
+Version information for:
+
+- sigrok-cli
+- libsigrok
+- libsigrokdecode
+
+## Example
+
+```
+Tool: show_version
+```
+
+## Notes
+
+- Useful for verifying the server is running and checking library versions.
+- This is a good first tool to call when testing a new connection.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: sigrok-mcp-server
+site_description: MCP server that exposes sigrok's signal analysis capabilities to LLMs
+site_url: https://kenosinc.github.io/sigrok-mcp-server
+repo_url: https://github.com/KenosInc/sigrok-mcp-server
+repo_name: KenosInc/sigrok-mcp-server
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - attr_list
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quick-start.md
+      - Firmware: getting-started/firmware.md
+  - Tools:
+      - Overview: tools/index.md
+      - list_supported_hardware: tools/list-supported-hardware.md
+      - list_supported_decoders: tools/list-supported-decoders.md
+      - list_input_formats: tools/list-input-formats.md
+      - list_output_formats: tools/list-output-formats.md
+      - show_decoder_details: tools/show-decoder-details.md
+      - show_driver_details: tools/show-driver-details.md
+      - show_version: tools/show-version.md
+      - scan_devices: tools/scan-devices.md
+      - capture_data: tools/capture-data.md
+      - decode_protocol: tools/decode-protocol.md
+      - check_firmware_status: tools/check-firmware-status.md
+      - serial_query: tools/serial-query.md
+      - get_device_profile: tools/get-device-profile.md
+  - Guides:
+      - Workflow Example: guides/workflow-example.md
+      - Troubleshooting: guides/troubleshooting.md
+  - Devices:
+      - Overview: devices/index.md
+      - OWON XDM1241: devices/owon-xdm1241.md
+  - Development:
+      - Architecture: development/architecture.md
+      - Contributing: development/contributing.md


### PR DESCRIPTION
## Summary

- Add MkDocs Material documentation site with structured sections: Getting Started, Tools reference, Guides, Devices, and Development
- Add GitHub Actions workflow for automatic deployment to GitHub Pages on push to main
- Add documentation site link to README

## Details

26 new documentation pages covering:
- **Getting Started:** Installation (Docker/source), Quick Start (Claude Desktop/Code config), Firmware guide
- **Tools:** Individual reference pages for all 13 MCP tools with parameters, examples, and notes
- **Guides:** Workflow example (end-to-end signal analysis), Troubleshooting (common issues and fixes)
- **Devices:** Device index and existing OWON XDM1241 documentation
- **Development:** Architecture overview, Contributing guide

## Test plan

- [ ] Verify `mkdocs build` succeeds locally with `pip install mkdocs-material && mkdocs build`
- [ ] Verify `mkdocs serve` renders all pages correctly
- [ ] Verify GitHub Pages deployment works after merge
- [ ] Check all internal links resolve correctly
- [ ] Enable GitHub Pages in repo settings (Source: Deploy from a branch, Branch: gh-pages)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation site with installation, quick-start, and setup guides.
  * Added detailed tool documentation covering all available features and usage examples.
  * Added troubleshooting guide, workflow examples, and device compatibility information.
  * Added development architecture and contribution guidelines.

* **Chores**
  * Configured automated documentation deployment to GitHub Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->