### PR TITLE
chore: add MCP Registry metadata for publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ RUN ldconfig
 # Copy Go binary from builder
 COPY --from=go-builder /sigrok-mcp-server /usr/local/bin/sigrok-mcp-server
 
+# MCP Registry verification label
+LABEL io.modelcontextprotocol.server.name="io.github.kenosinc/sigrok-mcp-server"
+
 # Smoke-test: verify sigrok-cli works and includes kingst driver
 RUN sigrok-cli --version \
     && sigrok-cli --list-supported | grep -q kingst

--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ internal/
 ## License
 
 MIT (Kenos, Inc.)
+
+<!-- mcp-name: io.github.kenosinc/sigrok-mcp-server -->

--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kenosinc/sigrok-mcp-server",
+  "title": "sigrok MCP Server",
+  "description": "An MCP server wrapping sigrok-cli for signal analysis — scan logic analyzers, capture data, decode protocols (UART, SPI, I2C, etc.), and query serial instruments via SCPI.",
+  "repository": {
+    "url": "https://github.com/KenosInc/sigrok-mcp-server",
+    "source": "github"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/kenosinc/sigrok-mcp-server:main",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Path to sigrok-cli binary",
+          "isRequired": false,
+          "name": "SIGROK_CLI_PATH"
+        },
+        {
+          "description": "Command execution timeout in seconds",
+          "isRequired": false,
+          "name": "SIGROK_TIMEOUT_SECONDS"
+        },
+        {
+          "description": "Working directory for sigrok-cli execution",
+          "isRequired": false,
+          "name": "SIGROK_WORKING_DIR"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `server.json` for publishing to the official MCP Registry
- Add OCI verification LABEL to Dockerfile
- Add `mcp-name` comment to README for additional verification

## Details

Prepares the project for publishing to the [official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.kenosinc/sigrok-mcp-server`.

**Verification metadata:**
- `Dockerfile`: `LABEL io.modelcontextprotocol.server.name` (required for OCI image verification)
- `README.md`: `<!-- mcp-name: ... -->` comment (additional verification)
- `server.json`: Registry metadata with package type `oci` pointing to `ghcr.io/kenosinc/sigrok-mcp-server:main`

## After merge

Once the Docker image is rebuilt with the new LABEL, publish to the registry:

```bash
brew install mcp-publisher
mcp-publisher login github
mcp-publisher publish
```

## Test plan

- [ ] Verify Docker image rebuilds with the LABEL
- [ ] Verify `mcp-publisher publish --dry-run` succeeds
- [ ] Verify server appears on https://registry.modelcontextprotocol.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)