### PR TITLE
ci: automate MCP Registry publishing on version tags

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -17,7 +17,10 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          BASE=https://github.com/modelcontextprotocol/registry/releases/latest/download
+          curl -L "${BASE}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
@@ -30,7 +33,10 @@ jobs:
       - name: Update OCI image tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          jq --arg id "ghcr.io/kenosinc/sigrok-mcp-server:${VERSION}" '.packages[0].identifier = $id' server.json > server.tmp && mv server.tmp server.json
+          IMAGE="ghcr.io/kenosinc/sigrok-mcp-server:${VERSION}"
+          jq --arg id "$IMAGE" \
+            '.packages[0].identifier = $id' \
+            server.json > server.tmp && mv server.tmp server.json
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically publish to the official MCP Registry on version tag push (`v*`)

## Details

Uses OIDC authentication (no secrets required). On tag push:

1. Downloads `mcp-publisher` CLI
2. Authenticates via GitHub OIDC → `io.github.kenosinc/*` namespace
3. Updates `server.json` version and OCI image tag from the git tag
4. Publishes to `registry.modelcontextprotocol.io`

**Flow:** `git tag v0.1.0 && git push origin v0.1.0` → Docker image built + MCP Registry updated

## Test plan

- [ ] Verify workflow triggers on tag push
- [ ] Verify `mcp-publisher publish` succeeds
- [ ] Verify server appears at https://registry.modelcontextprotocol.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated the publishing process to the MCP Registry through GitHub Actions workflow triggered on version tag releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->