### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.kenosinc/sigrok-mcp-server",
   "title": "sigrok MCP Server",
-  "description": "An MCP server wrapping sigrok-cli for signal analysis — scan logic analyzers, capture data, decode protocols (UART, SPI, I2C, etc.), and query serial instruments via SCPI.",
+  "description": "Wraps sigrok-cli for signal analysis: capture data, decode protocols, and query instruments.",
   "repository": {
     "url": "https://github.com/KenosInc/sigrok-mcp-server",
     "source": "github"


### PR DESCRIPTION
## Summary

- Shorten `server.json` description from 171 to 92 characters to meet the MCP Registry's 100-character limit

## Context

The MCP Registry publish workflow failed with:
```
"location":"body.description","message":"expected length <= 100"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)