### PR TITLE
fix: match MCP Registry namespace case to GitHub org name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN ldconfig
 COPY --from=go-builder /sigrok-mcp-server /usr/local/bin/sigrok-mcp-server
 
 # MCP Registry verification label
-LABEL io.modelcontextprotocol.server.name="io.github.kenosinc/sigrok-mcp-server"
+LABEL io.modelcontextprotocol.server.name="io.github.KenosInc/sigrok-mcp-server"
 
 # Smoke-test: verify sigrok-cli works and includes kingst driver
 RUN sigrok-cli --version \

--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ internal/
 
 MIT (Kenos, Inc.)
 
-<!-- mcp-name: io.github.kenosinc/sigrok-mcp-server -->
+<!-- mcp-name: io.github.KenosInc/sigrok-mcp-server -->

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.kenosinc/sigrok-mcp-server",
+  "name": "io.github.KenosInc/sigrok-mcp-server",
   "title": "sigrok MCP Server",
   "description": "Wraps sigrok-cli for signal analysis: capture data, decode protocols, and query instruments.",
   "repository": {


### PR DESCRIPTION
## Summary

- Fix MCP Registry namespace from `io.github.kenosinc` to `io.github.KenosInc` (case-sensitive match required)

## Context

The MCP Registry publish workflow failed with:
```
You have permission to publish: io.github.KenosInc/*.
Attempting to publish: io.github.kenosinc/sigrok-mcp-server.
```

The registry requires the namespace to match the GitHub organization name exactly, including case.

## Changes

- `server.json`: name field
- `Dockerfile`: LABEL
- `README.md`: mcp-name comment

## Test plan

- [ ] Verify Docker image rebuilds with corrected LABEL
- [ ] Verify MCP Registry publish succeeds on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected organization namespace capitalization across configuration files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->